### PR TITLE
Deactivate audio session on iOS

### DIFF
--- a/ios/Classes/SwiftSpeechToTextPlugin.swift
+++ b/ios/Classes/SwiftSpeechToTextPlugin.swift
@@ -234,6 +234,12 @@ public class SwiftSpeechToTextPlugin: NSObject, FlutterPlugin {
         catch {
             os_log("Error stopping listen: %{PUBLIC}@", log: pluginLog, type: .error, error.localizedDescription)
         }
+        do {
+            try self.audioSession.setActive(false, options: .notifyOthersOnDeactivation)
+        }
+        catch {
+            os_log("Error deactivation: %{PUBLIC}@", log: pluginLog, type: .error, error.localizedDescription)
+        }
         currentRequest = nil
         currentTask = nil
     }


### PR DESCRIPTION
On iOS, when I use the plugin, other audio level becomes low
even I call `speech.stop()` or `speech.cancel()` .

This change deactivates audio session in `stopCurrentListen` method
to restore other audio level.
