### PR TITLE
Implement null safety for Platform Interface

### DIFF
--- a/speech_to_text_platform_interface/lib/method_channel_speech_to_text.dart
+++ b/speech_to_text_platform_interface/lib/method_channel_speech_to_text.dart
@@ -24,22 +24,26 @@ class MethodChannelSpeechToText extends SpeechToTextPlatform {
   /// Note that applications cannot ask for permission again if the user has
   /// denied them permission in the past.
   @override
-  Future<bool> hasPermission() {
-    return _channel.invokeMethod<bool>('has_permission');
+  Future<bool> hasPermission() async {
+    var result = await _channel.invokeMethod<bool>('has_permission');
+
+    return result!;
   }
 
   @override
   Future<bool> initialize(
-      {debugLogging = false, List<SpeechConfigOption> options}) {
+      {debugLogging = false, List<SpeechConfigOption>? options}) async {
     _channel.setMethodCallHandler(_handleCallbacks);
     var params = <String, Object>{
       'debugLogging': debugLogging,
     };
     options?.forEach((option) => params[option.name] = option.value);
-    return _channel.invokeMethod<bool>(
+    var result = await _channel.invokeMethod<bool>(
       'initialize',
       params,
     );
+
+    return result!;
   }
 
   /// Stops the current listen for speech if active, does nothing if not.
@@ -97,11 +101,11 @@ class MethodChannelSpeechToText extends SpeechToTextPlatform {
   ///
   @override
   Future<bool> listen(
-      {String localeId,
+      {String? localeId,
       partialResults = true,
       onDevice = false,
       int listenMode = 0,
-      sampleRate = 0}) {
+      sampleRate = 0}) async {
     Map<String, dynamic> listenParams = {
       "partialResults": partialResults,
       "onDevice": onDevice,
@@ -111,14 +115,18 @@ class MethodChannelSpeechToText extends SpeechToTextPlatform {
     if (null != localeId) {
       listenParams["localeId"] = localeId;
     }
-    return _channel.invokeMethod('listen', listenParams);
+    var result = await _channel.invokeMethod<bool>('listen', listenParams);
+
+    return result!;
   }
 
   /// returns the list of speech locales available on the device.
   ///
   @override
-  Future<List<dynamic>> locales() {
-    return _channel.invokeMethod('locales');
+  Future<List<dynamic>> locales() async {
+    var result = await _channel.invokeMethod<List<dynamic>>('locales');
+
+    return result!;
   }
 
   Future _handleCallbacks(MethodCall call) async {
@@ -126,22 +134,22 @@ class MethodChannelSpeechToText extends SpeechToTextPlatform {
     switch (call.method) {
       case textRecognitionMethod:
         if (call.arguments is String && null != onTextRecognition) {
-          onTextRecognition(call.arguments);
+          onTextRecognition!(call.arguments);
         }
         break;
       case notifyErrorMethod:
         if (call.arguments is String && null != onError) {
-          onError(call.arguments);
+          onError!(call.arguments);
         }
         break;
       case notifyStatusMethod:
         if (call.arguments is String && null != onStatus) {
-          onStatus(call.arguments);
+          onStatus!(call.arguments);
         }
         break;
       case soundLevelChangeMethod:
         if (call.arguments is double && null != onSoundLevel) {
-          onSoundLevel(call.arguments);
+          onSoundLevel!(call.arguments);
         }
         break;
       default:

--- a/speech_to_text_platform_interface/lib/speech_to_text_platform_interface.dart
+++ b/speech_to_text_platform_interface/lib/speech_to_text_platform_interface.dart
@@ -51,10 +51,10 @@ abstract class SpeechToTextPlatform extends PlatformInterface {
     _instance = instance;
   }
 
-  void Function(String results) onTextRecognition;
-  void Function(String error) onError;
-  void Function(String status) onStatus;
-  void Function(double level) onSoundLevel;
+  void Function(String results)? onTextRecognition;
+  void Function(String error)? onError;
+  void Function(String status)? onStatus;
+  void Function(double level)? onSoundLevel;
 
   /// Returns true if the user has already granted permission to access the
   /// microphone, does not prompt the user.
@@ -83,7 +83,7 @@ abstract class SpeechToTextPlatform extends PlatformInterface {
   /// plugins. It is off by default, usually only useful for troubleshooting issues
   /// with a paritcular OS version or device, fairly verbose
   Future<bool> initialize(
-      {debugLogging = false, List<SpeechConfigOption> options}) {
+      {debugLogging = false, List<SpeechConfigOption>? options}) {
     throw UnimplementedError('initialize() has not been implemented.');
   }
 
@@ -139,10 +139,10 @@ abstract class SpeechToTextPlatform extends PlatformInterface {
   /// crashes
   ///
   Future<bool> listen(
-      {String localeId,
+      {String? localeId,
       partialResults = true,
       onDevice = false,
-      int listenMode,
+      int listenMode = 0,
       sampleRate = 0}) {
     throw UnimplementedError('listen() has not been implemented.');
   }

--- a/speech_to_text_platform_interface/pubspec.lock
+++ b/speech_to_text_platform_interface/pubspec.lock
@@ -7,140 +7,140 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "7.0.0"
+    version: "14.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.39.17"
+    version: "0.41.2"
   args:
     dependency: transitive
     description:
       name: args
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.0"
+    version: "2.0.0"
   async:
     dependency: transitive
     description:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0-nullsafety.1"
+    version: "2.5.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.1"
+    version: "2.1.0"
   build:
     dependency: transitive
     description:
       name: build
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.0"
+    version: "1.6.2"
   built_collection:
     dependency: transitive
     description:
       name: built_collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.3.2"
+    version: "5.0.0"
   built_value:
     dependency: transitive
     description:
       name: built_value
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "7.1.0"
+    version: "8.0.0"
   characters:
     dependency: transitive
     description:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.3"
+    version: "1.1.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.1"
+    version: "1.2.0"
   cli_util:
     dependency: transitive
     description:
       name: cli_util
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.0"
+    version: "0.3.0"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.1"
+    version: "1.1.0"
   code_builder:
     dependency: transitive
     description:
       name: code_builder
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.5.0"
+    version: "3.6.0"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0-nullsafety.3"
+    version: "1.15.0"
   convert:
     dependency: transitive
     description:
       name: convert
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "3.0.0"
   crypto:
     dependency: transitive
     description:
       name: crypto
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.5"
-  csslib:
-    dependency: transitive
-    description:
-      name: csslib
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.16.2"
+    version: "3.0.0"
   dart_style:
     dependency: transitive
     description:
       name: dart_style
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.6"
+    version: "1.3.12"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.1"
+    version: "1.2.0"
+  file:
+    dependency: transitive
+    description:
+      name: file
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "6.0.0"
   fixnum:
     dependency: transitive
     description:
       name: fixnum
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.10.11"
+    version: "1.0.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -157,63 +157,35 @@ packages:
       name: glob
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
-  html:
-    dependency: transitive
-    description:
-      name: html
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.14.0+4"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.6.2"
+    version: "2.0.0"
   logging:
     dependency: transitive
     description:
       name: logging
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.11.4"
+    version: "1.0.0"
   matcher:
     dependency: transitive
     description:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10-nullsafety.1"
+    version: "0.12.10"
   meta:
     dependency: "direct main"
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.3"
+    version: "1.3.0"
   mockito:
     dependency: "direct dev"
     description:
       name: mockito
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.1.2"
-  node_interop:
-    dependency: transitive
-    description:
-      name: node_interop
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.1.1"
-  node_io:
-    dependency: transitive
-    description:
-      name: node_io
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.1.1"
+    version: "5.0.0-nullsafety.7"
   package_config:
     dependency: transitive
     description:
@@ -227,35 +199,28 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety.1"
+    version: "1.8.0"
   pedantic:
     dependency: "direct dev"
     description:
       name: pedantic
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.2"
+    version: "1.10.0"
   plugin_platform_interface:
     dependency: "direct main"
     description:
       name: plugin_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.3"
+    version: "1.1.0-nullsafety.2"
   pub_semver:
     dependency: transitive
     description:
       name: pub_semver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.4"
-  quiver:
-    dependency: transitive
-    description:
-      name: quiver
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.1.3"
+    version: "2.0.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -267,77 +232,76 @@ packages:
       name: source_gen
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.7+1"
+    version: "0.9.10+2"
   source_span:
     dependency: transitive
     description:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety.2"
+    version: "1.8.0"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.0-nullsafety.1"
+    version: "1.10.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.1"
+    version: "2.1.0"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.1"
+    version: "1.1.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.1"
+    version: "1.2.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19-nullsafety.2"
+    version: "0.2.19"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.3"
+    version: "1.3.0"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.3"
+    version: "2.1.0"
   watcher:
     dependency: transitive
     description:
       name: watcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.7+15"
+    version: "1.0.0"
   yaml:
     dependency: transitive
     description:
       name: yaml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.1"
+    version: "3.0.0"
 sdks:
-  dart: ">=2.10.0-110 <2.11.0"
-  flutter: ">=1.9.1+hotfix.4 <2.0.0"
+  dart: ">=2.12.0-0.0 <3.0.0"

--- a/speech_to_text_platform_interface/pubspec.yaml
+++ b/speech_to_text_platform_interface/pubspec.yaml
@@ -8,15 +8,14 @@ version: 1.4.2
 dependencies:
   flutter:
     sdk: flutter
-  meta: ^1.0.5
-  plugin_platform_interface: ^1.0.1
+  meta: ^1.3.0
+  plugin_platform_interface: ^1.1.0-nullsafety.2
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  mockito: ^4.1.1
-  pedantic: ^1.8.0
+  mockito: ^5.0.0-nullsafety.7
+  pedantic: ^1.10.0
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
-  flutter: ">=1.9.1+hotfix.4 <2.0.0"
+  sdk: ">=2.12.0-0 <3.0.0"


### PR DESCRIPTION
Several steps for null safety:
 * Update pubspec.yaml deps to null-safe ones
 * Remove unneeded flutter version dep, as newer Dart dep covers it
 * Channel "invokeMethod" calls return a nullable type, but it can't
   even actually be null, so we cast it away.
 * Instance variables don't convey null-safety to static analysis,
   so those are casted away.
 * listenMode on listen is initialized to zero.