### PR TITLE
Release 2.0.0-nullsafety

### DIFF
--- a/speech_to_text_platform_interface/CHANGELOG.md
+++ b/speech_to_text_platform_interface/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.0.0-nullsafety
+- prerelease for null safety / flutter 2.0 compatability
+
 ## 1.4.2
 - bug fix for null options
 

--- a/speech_to_text_platform_interface/pubspec.yaml
+++ b/speech_to_text_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the speech_to_text plugin.
 homepage: https://github.com/csdcorp/speech_to_text/speech_to_text_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 1.4.2
+version: 2.0.0-nullsafety
 
 dependencies:
   flutter:


### PR DESCRIPTION
This release adds nullsafety support (Part of Dart 2.12 / Flutter 2).  Because this is an API
breaking change, the major version is rolled.