### PR TITLE
Fix lint warning for control flow in finally

### DIFF
--- a/speech_to_text/lib/speech_to_text_web.dart
+++ b/speech_to_text/lib/speech_to_text_web.dart
@@ -47,6 +47,7 @@ class SpeechToTextPlugin extends SpeechToTextPlatform {
   @override
   Future<bool> initialize(
       {debugLogging = false, List<SpeechConfigOption>? options}) async {
+    var initialized = false;
     try {
       _webSpeech = ws.SpeechRecognition();
       if (null != _webSpeech) {
@@ -55,6 +56,7 @@ class SpeechToTextPlugin extends SpeechToTextPlatform {
         _webSpeech!.onspeechstart = allowInterop(_onSpeechStart);
         _webSpeech!.onend = allowInterop(_onSpeechEnd);
         _webSpeech!.onspeechend = allowInterop(_onSpeechEnd);
+        initialized = true;
       }
     } finally {
       if (null == _webSpeech) {
@@ -62,10 +64,9 @@ class SpeechToTextPlugin extends SpeechToTextPlatform {
           var error = SpeechRecognitionError('speech_not_supported', true);
           onError!(jsonEncode(error.toJson()));
         }
-        return false;
       }
     }
-    return null != _webSpeech;
+    return initialized;
   }
 
   /// Stops the current listen for speech if active, does nothing if not.


### PR DESCRIPTION
https://pub.dev/packages/speech_to_text/versions/4.1.0-nullsafety/score
has a warning and a lower score because of the return in the finally
block in web handling.  This currently
costs 10 points in the "Pass static analysis" score.

I think the change is worthwhile both from not having the package
penalized, but also because it's easy to see what the return state is
now from the variable name.

Tested:
Not at all.