### PR TITLE
Fixing breaking Changes on test

### DIFF
--- a/speech_to_text_platform_interface/lib/method_channel_speech_to_text.dart
+++ b/speech_to_text_platform_interface/lib/method_channel_speech_to_text.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 import 'speech_to_text_platform_interface.dart';
 


### PR DESCRIPTION
The `setMockMethodCallHandler` method migrated to flutter_test so we just need to import that package :)