### PR TITLE
Update build.gradle

### DIFF
--- a/multi_platform_example/android/app/build.gradle
+++ b/multi_platform_example/android/app/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
@@ -35,7 +35,7 @@ android {
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.csdcorp.app.multi_platform_example"
-        minSdkVersion 16
+        minSdkVersion 21
         targetSdkVersion 30
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName


### PR DESCRIPTION
Without this, building fails with errors like:
E:\AndroidStudioProjects\speech_to_text\multi_platform_example\android\app\src\debug\AndroidManifest.xml Error:
	uses-sdk:minSdkVersion 16 cannot be smaller than version 21 declared in library [:speech_to_text] E:\AndroidStudioProjects\speech_to_text\multi_platform_example\build\speech_to_text\intermediates\library_manifest\debug\AndroidManifest.xml as the library might be using APIs not available in 16
	Suggestion: use a compatible library with a minSdk of at most 16,
		or increase this project's minSdk version to at least 21,
		or use tools:overrideLibrary="com.csdcorp.speech_to_text" to force usage (may lead to runtime failures)

FAILURE: Build failed with an exception.