### PR TITLE
Feature: Make options available to provider

### DIFF
--- a/speech_to_text/lib/speech_to_text.dart
+++ b/speech_to_text/lib/speech_to_text.dart
@@ -107,7 +107,7 @@ class SpeechToText {
   /// This allows the done status to be sent from the plugin to clients
   /// even without a final speech result.
   static const String _doneNoResultStatus = 'doneNoResult';
-  static const _defaultFinalTimeout = Duration(milliseconds: 2000);
+  static const defaultFinalTimeout = Duration(milliseconds: 2000);
   static const _minFinalTimeout = Duration(milliseconds: 50);
 
   /// on Android SDK 29 the recognizer stop method did not work properly so the
@@ -163,7 +163,7 @@ class SpeechToText {
   int _lastSpeechEventAt = 0;
   Duration? _pauseFor;
   Duration? _listenFor;
-  Duration _finalTimeout = _defaultFinalTimeout;
+  Duration _finalTimeout = defaultFinalTimeout;
 
   /// True if not listening or the user called cancel / stop, false
   /// if cancel/stop were invoked by timeout or error condition.
@@ -272,7 +272,7 @@ class SpeechToText {
       {SpeechErrorListener? onError,
       SpeechStatusListener? onStatus,
       debugLogging = false,
-      Duration finalTimeout = _defaultFinalTimeout,
+      Duration finalTimeout = defaultFinalTimeout,
       List<SpeechConfigOption>? options}) async {
     if (_initWorked) {
       return Future.value(_initWorked);

--- a/speech_to_text/lib/speech_to_text_provider.dart
+++ b/speech_to_text/lib/speech_to_text_provider.dart
@@ -5,6 +5,7 @@ import 'package:speech_to_text/speech_recognition_error.dart';
 import 'package:speech_to_text/speech_recognition_event.dart';
 import 'package:speech_to_text/speech_recognition_result.dart';
 import 'package:speech_to_text/speech_to_text.dart';
+import 'package:speech_to_text_platform_interface/speech_to_text_platform_interface.dart';
 
 /// Simplifies interaction with [SpeechToText] by handling all the callbacks and notifying
 /// listeners as events happen.
@@ -54,14 +55,21 @@ class SpeechToTextProvider extends ChangeNotifier {
   /// Initializes the provider and the contained [SpeechToText] instance.
   ///
   /// Returns true if [SpeechToText] was initialized successful and can now
-  /// be used, false otherwse.
-  Future<bool> initialize() async {
+  /// be used, false otherwise.
+  Future<bool> initialize(
+      {debugLogging = false,
+      Duration finalTimeout = SpeechToText.defaultFinalTimeout,
+      List<SpeechConfigOption>? options}) async {
     if (isAvailable) {
       return isAvailable;
     }
     var availableBefore = _speechToText.isAvailable;
-    var available =
-        await _speechToText.initialize(onStatus: _onStatus, onError: _onError);
+    var available = await _speechToText.initialize(
+        onStatus: _onStatus,
+        onError: _onError,
+        debugLogging: debugLogging,
+        finalTimeout: finalTimeout,
+        options: options);
     if (available) {
       _locales = [];
       _locales.addAll(await _speechToText.locales());


### PR DESCRIPTION
The options parameter of the initialize method is not available in the provider implementation of speech_to_text.
This PR makes them available.