### PR TITLE
Made BLUETOOTH_ADMIN permission optional

### DIFF
--- a/speech_to_text/android/src/main/kotlin/com/csdcorp/speech_to_text/SpeechToTextPlugin.kt
+++ b/speech_to_text/android/src/main/kotlin/com/csdcorp/speech_to_text/SpeechToTextPlugin.kt
@@ -311,6 +311,10 @@ public class SpeechToTextPlugin :
 
     private fun optionallyStartBluetooth() {
         if ( noBluetooth ) return 
+        val context = pluginContext
+        if (Build.VERSION.SDK_INT>=23 && context != null && context.checkSelfPermission(Manifest.permission.BLUETOOTH_ADMIN) != PackageManager.PERMISSION_GRANTED) {
+            return
+        }
         val lbt = bluetoothAdapter
         val lpaired = pairedDevices
         val lhead = bluetoothHeadset


### PR DESCRIPTION
Currently there is SecutiryException thrown, and speech recognition does not work. IMHO better behavior is to allow speech recognition with internal microphone for which user already gave permission.