### PR TITLE
Add setPauseFor method for late setup

### DIFF
--- a/speech_to_text/lib/speech_to_text.dart
+++ b/speech_to_text/lib/speech_to_text.dart
@@ -435,6 +435,16 @@ class SpeechToText {
       throw ListenFailedException(e.message, e.details, e.stacktrace);
     }
   }
+  void setPauseFor(Duration pauseFor) {
+    //Setup new pauseFor only if listen is active and pauseFor is different
+    if ((_listenTimer?.isActive ?? false) && (_pauseFor == null || _pauseFor!.compareTo(pauseFor) != 0)) {
+      _listenTimer?.cancel();
+      _listenTimer = null;
+      _setupListenAndPause(pauseFor, _listenFor);
+    } else {
+      throw ListenNotStartedException();
+    }
+  }
 
   void _setupListenAndPause(
       Duration? initialPauseFor, Duration? initialListenFor) {
@@ -658,3 +668,5 @@ class ListenFailedException implements Exception {
   final String? stackTrace;
   ListenFailedException(this.message, [this.details, this.stackTrace]);
 }
+
+class ListenNotStartedException implements Exception {}

--- a/speech_to_text/lib/speech_to_text.dart
+++ b/speech_to_text/lib/speech_to_text.dart
@@ -435,7 +435,7 @@ class SpeechToText {
       throw ListenFailedException(e.message, e.details, e.stacktrace);
     }
   }
-  void setPauseFor(Duration pauseFor) {
+  void changePauseFor(Duration pauseFor) {
     //Setup new pauseFor only if listen is active and pauseFor is different
     if ((_listenTimer?.isActive ?? false) && (_pauseFor == null || _pauseFor!.compareTo(pauseFor) != 0)) {
       _listenTimer?.cancel();

--- a/speech_to_text/lib/speech_to_text.dart
+++ b/speech_to_text/lib/speech_to_text.dart
@@ -437,12 +437,16 @@ class SpeechToText {
   }
   void changePauseFor(Duration pauseFor) {
     //Setup new pauseFor only if listen is active and pauseFor is different
-    if ((_listenTimer?.isActive ?? false) && (_pauseFor == null || _pauseFor!.compareTo(pauseFor) != 0)) {
+    if(isNotListening) {
+      throw ListenNotStartedException();
+    }
+
+    if (_pauseFor == null || _pauseFor!.compareTo(pauseFor) != 0) {
       _listenTimer?.cancel();
       _listenTimer = null;
+      //Reset _lastSpeechEventAt for new pauseFor duration will count from now but not from start of listen
+      _lastSpeechEventAt = clock.now().millisecondsSinceEpoch;
       _setupListenAndPause(pauseFor, _listenFor);
-    } else {
-      throw ListenNotStartedException();
     }
   }
 

--- a/speech_to_text/lib/speech_to_text.dart
+++ b/speech_to_text/lib/speech_to_text.dart
@@ -444,14 +444,13 @@ class SpeechToText {
     if (_pauseFor == null || _pauseFor!.compareTo(pauseFor) != 0) {
       _listenTimer?.cancel();
       _listenTimer = null;
-      //Reset _lastSpeechEventAt for new pauseFor duration will count from now but not from start of listen
-      _lastSpeechEventAt = clock.now().millisecondsSinceEpoch;
-      _setupListenAndPause(pauseFor, _listenFor);
+      //Ignore elapsed pause for prevent immediately stop listen
+      _setupListenAndPause(pauseFor, _listenFor, ignoreElapsedPause: true);
     }
   }
 
   void _setupListenAndPause(
-      Duration? initialPauseFor, Duration? initialListenFor) {
+      Duration? initialPauseFor, Duration? initialListenFor, {bool ignoreElapsedPause = false}) {
     _pauseFor = null;
     _listenFor = null;
     if (null == initialPauseFor && null == initialListenFor) {
@@ -460,7 +459,7 @@ class SpeechToText {
     var pauseFor = initialPauseFor;
     var listenFor = initialListenFor;
     if (null != pauseFor) {
-      var remainingMillis = pauseFor.inMilliseconds - _elapsedSinceSpeechEvent;
+      var remainingMillis = pauseFor.inMilliseconds - (ignoreElapsedPause ? 0 : _elapsedSinceSpeechEvent);
       pauseFor = Duration(milliseconds: max(remainingMillis, 0));
     }
     if (null != listenFor) {

--- a/speech_to_text/test/speech_to_text_test.dart
+++ b/speech_to_text/test/speech_to_text_test.dart
@@ -195,7 +195,7 @@ void main() {
         fa.flushMicrotasks();
         expect(speech.isListening, isFalse);
         try {
-          speech.setPauseFor(Duration(seconds: 5));
+          speech.changePauseFor(Duration(seconds: 5));
           fail('Should have thrown');
         } on ListenNotStartedException {
           // This is a good result
@@ -213,7 +213,7 @@ void main() {
         fa.flushMicrotasks();
         expect(speech.isListening, isTrue);
         fa.elapse(Duration(seconds: 1));
-        speech.setPauseFor(Duration(seconds: 5));
+        speech.changePauseFor(Duration(seconds: 5));
         fa.flushMicrotasks();
         fa.elapse(Duration(seconds: 3));
         expect(speech.isListening, isTrue);
@@ -230,7 +230,7 @@ void main() {
         fa.flushMicrotasks();
         fa.elapse(Duration(seconds: 1));
         expect(speech.isListening, isTrue);
-        speech.setPauseFor(Duration(seconds: 5));
+        speech.changePauseFor(Duration(seconds: 5));
         fa.flushMicrotasks();
         fa.elapse(Duration(seconds: 3));
         expect(speech.isListening, isTrue);

--- a/speech_to_text/test/speech_to_text_test.dart
+++ b/speech_to_text/test/speech_to_text_test.dart
@@ -241,22 +241,6 @@ void main() {
         expect(speech.isListening, isTrue);
       });
     });
-    test('creates finalResult true if none provided', () async {
-      fakeAsync((fa) {
-        speech.initialize(finalTimeout: Duration(milliseconds: 100));
-        fa.flushMicrotasks();
-        speech.listen(
-            pauseFor: Duration(seconds: 2), onResult: listener.onSpeechResult);
-        fa.flushMicrotasks();
-        testPlatform
-            .onTextRecognition!(TestSpeechChannelHandler.firstRecognizedJson);
-        fa.flushMicrotasks();
-        // 2200 because it is the 2 second duration of the pauseFor then
-        // 100 milliseconds to create the synthetic result
-        fa.elapse(Duration(milliseconds: 2100));
-        expect(listener.results.last.finalResult, isTrue);
-      });
-    });
     test('Stop listen after late changePauseFor without initial pauseFor', () async {
       fakeAsync((fa) {
         speech.initialize();
@@ -274,6 +258,22 @@ void main() {
         fa.elapse(Duration(seconds: 2));
         fa.flushMicrotasks();
         expect(speech.isListening, isFalse);
+      });
+    });
+    test('creates finalResult true if none provided', () async {
+      fakeAsync((fa) {
+        speech.initialize(finalTimeout: Duration(milliseconds: 100));
+        fa.flushMicrotasks();
+        speech.listen(
+            pauseFor: Duration(seconds: 2), onResult: listener.onSpeechResult);
+        fa.flushMicrotasks();
+        testPlatform
+            .onTextRecognition!(TestSpeechChannelHandler.firstRecognizedJson);
+        fa.flushMicrotasks();
+        // 2200 because it is the 2 second duration of the pauseFor then
+        // 100 milliseconds to create the synthetic result
+        fa.elapse(Duration(milliseconds: 2100));
+        expect(listener.results.last.finalResult, isTrue);
       });
     });
     test('respects finalTimeout', () async {

--- a/speech_to_text/test/speech_to_text_test.dart
+++ b/speech_to_text/test/speech_to_text_test.dart
@@ -187,7 +187,7 @@ void main() {
         expect(speech.isListening, isTrue);
       });
     });
-    test('trows on setPauseFor when not listening', () async {
+    test('trows on changePauseFor when not listening', () async {
       fakeAsync((fa) {
         speech.initialize();
         fa.flushMicrotasks();
@@ -204,7 +204,7 @@ void main() {
         }
       });
     });
-    test('stops listen after late setPauseFor with no speech', () async {
+    test('stops listen after late changePauseFor with no speech', () async {
       fakeAsync((fa) {
         speech.initialize();
         fa.flushMicrotasks();
@@ -221,7 +221,7 @@ void main() {
         expect(speech.isListening, isFalse);
       });
     });
-    test('keeps listening after late setPauseFor with speech event', () async {
+    test('keeps listening after late changePauseFor with speech event', () async {
       fakeAsync((fa) {
         speech.initialize();
         fa.flushMicrotasks();
@@ -255,6 +255,25 @@ void main() {
         // 100 milliseconds to create the synthetic result
         fa.elapse(Duration(milliseconds: 2100));
         expect(listener.results.last.finalResult, isTrue);
+      });
+    });
+    test('Stop listen after late changePauseFor without initial pauseFor', () async {
+      fakeAsync((fa) {
+        speech.initialize();
+        fa.flushMicrotasks();
+        speech.listen();
+        testPlatform.onStatus!(SpeechToText.listeningStatus);
+        fa.flushMicrotasks();
+        fa.elapse(Duration(seconds: 5));
+        expect(speech.isListening, isTrue);
+        fa.elapse(Duration(seconds: 1));
+        speech.changePauseFor(Duration(seconds: 5));
+        fa.elapse(Duration(seconds: 3));
+        fa.flushMicrotasks();
+        expect(speech.isListening, isTrue);
+        fa.elapse(Duration(seconds: 2));
+        fa.flushMicrotasks();
+        expect(speech.isListening, isFalse);
       });
     });
     test('respects finalTimeout', () async {


### PR DESCRIPTION
This enable to setup puseFor timeout after start listening.

Reason: in my app I try to implement continuous conversation. So when start listentening after previous reposne, user may think longer. It more UX friendly if start listening with longer pauseFor (e.g. 10 sec) and after first onResult, chage pauseFor to short timeout (e.g. 3 sec.) 