### PR TITLE
Merge alternatives to detect if user continues

### DIFF
--- a/speech_to_text/lib/speech_to_text.dart
+++ b/speech_to_text/lib/speech_to_text.dart
@@ -491,15 +491,20 @@ class SpeechToText {
     }
     var pauseFor = initialPauseFor;
     var listenFor = initialListenFor;
-    if (null != pauseFor) {
-      var remainingMillis = pauseFor.inMilliseconds -
-          (ignoreElapsedPause ? 0 : _elapsedSinceSpeechEvent);
-      pauseFor = Duration(milliseconds: max(remainingMillis, 0));
-    }
-    if (null != listenFor) {
-      var remainingMillis = listenFor.inMilliseconds - _elapsedListenMillis;
-      listenFor = Duration(milliseconds: max(remainingMillis, 0));
-    }
+    // This section does not make sense to me. As we stop the listen according
+    // to the variables _elapsedListenMillis and _elapsedSinceSpeechEvent, why
+    // do we need to update our reference values?
+    // _elapsedListenMillis & _elapsedSinceSpeechEvent are being updated already
+    // Tested on web and solves an issue of early timeout.
+    // if (null != pauseFor) {
+    //   var remainingMillis = pauseFor.inMilliseconds -
+    //       (ignoreElapsedPause ? 0 : _elapsedSinceSpeechEvent);
+    //   pauseFor = Duration(milliseconds: max(remainingMillis, 0));
+    // }
+    // if (listenFor != null) {
+    //   var remainingMillis = listenFor.inMilliseconds - _elapsedListenMillis;
+    //   listenFor = Duration(milliseconds: max(remainingMillis, 0));
+    // }
     Duration minDuration;
     if (null == pauseFor) {
       _listenFor = Duration(milliseconds: listenFor!.inMilliseconds);

--- a/speech_to_text/lib/speech_to_text.dart
+++ b/speech_to_text/lib/speech_to_text.dart
@@ -613,6 +613,17 @@ class SpeechToText {
     if (_lastSpeechResult == null || _lastSpeechResult != speechResult) {
       _lastSpeechEventAt = clock.now().millisecondsSinceEpoch;
     }
+    if (speechResult.alternates.length > 1) {
+      // Merge all alternates into one string
+      var recognizedWords = speechResult.alternates
+          .map((alternate) => alternate.recognizedWords)
+          .join(' ')
+          .replaceAll('  ', ' ');
+      speechResult = SpeechRecognitionResult([
+        SpeechRecognitionWords(
+            recognizedWords, speechResult.alternates.first.confidence)
+      ], speechResult.finalResult);
+    }
     _lastSpeechResult = speechResult;
     if (!_partialResults && !speechResult.finalResult) {
       return;

--- a/speech_to_text/lib/speech_to_text.dart
+++ b/speech_to_text/lib/speech_to_text.dart
@@ -610,9 +610,6 @@ class SpeechToText {
 
   void _notifyResults(SpeechRecognitionResult speechResult) {
     if (_notifiedFinal) return;
-    if (_lastSpeechResult == null || _lastSpeechResult != speechResult) {
-      _lastSpeechEventAt = clock.now().millisecondsSinceEpoch;
-    }
     if (speechResult.alternates.length > 1) {
       // Merge all alternates into one string
       var recognizedWords = speechResult.alternates
@@ -623,6 +620,9 @@ class SpeechToText {
         SpeechRecognitionWords(
             recognizedWords, speechResult.alternates.first.confidence)
       ], speechResult.finalResult);
+    }
+    if (_lastSpeechResult == null || _lastSpeechResult != speechResult) {
+      _lastSpeechEventAt = clock.now().millisecondsSinceEpoch;
     }
     _lastSpeechResult = speechResult;
     if (!_partialResults && !speechResult.finalResult) {


### PR DESCRIPTION
This is the simple fix that solves the issue where the user takes a small break in speaking that is less than the configured pause. In that case the speech recognition would stop as after a break, further detection becomes part of the next element in alternatives. Right now I can't find further reasons why the alternatives were defined like this.

This has been tested on Web.