### PR TITLE
Add '.mixWithOthers' option in audio session category to make speech to text work perfectly when IOS devices are playing audio

### DIFF
--- a/speech_to_text/ios/Classes/SwiftSpeechToTextPlugin.swift
+++ b/speech_to_text/ios/Classes/SwiftSpeechToTextPlugin.swift
@@ -380,7 +380,7 @@ public class SwiftSpeechToTextPlugin: NSObject, FlutterPlugin {
             }
             rememberedAudioCategory = self.audioSession.category
             rememberedAudioCategoryOptions = self.audioSession.categoryOptions
-            try self.audioSession.setCategory(AVAudioSession.Category.playAndRecord, options: [.defaultToSpeaker,.allowBluetooth,.allowBluetoothA2DP])
+            try self.audioSession.setCategory(AVAudioSession.Category.playAndRecord, options: [.defaultToSpeaker,.allowBluetooth,.allowBluetoothA2DP,.mixWithOthers])
             //            try self.audioSession.setMode(AVAudioSession.Mode.measurement)
             if ( sampleRate > 0 ) {
                 try self.audioSession.setPreferredSampleRate(Double(sampleRate))


### PR DESCRIPTION
relate to #487 #472 