### PR TITLE
PR to fix issue with first word missed on iOS on 2nd+ calls to listen…

### DIFF
--- a/speech_to_text/pubspec.yaml
+++ b/speech_to_text/pubspec.yaml
@@ -1,6 +1,6 @@
 name: speech_to_text
 description: A Flutter plugin that exposes device specific speech to text recognition capability.
-version: 6.6.1
+version: 6.6.2
 homepage: https://github.com/csdcorp/speech_to_text
 
 environment:


### PR DESCRIPTION
iOS does not recognize the first word after calling the .listen() for second time and further, i.e. listen (all good here) -> stop -> listen (missed first word) -> stop -> etc...

If I benchmark the time from try self.audioEngine.start() to the first buffer received in the callback of inputNode?.installTap, there is approx. 175ms, which is sufficient to catch the first word. However on the second+ call to listenForSpeech, the same benchmark results in approx. 850ms, which is more than enough to miss the first word.

After experimenting a bit, I noticed that instantiating a new audioEngine and of course inputNode fixes this issue and we are back on cirka 175ms before receiving the first buffer on second+ calls. 