### PR TITLE
Map ListenMode.search to LANGUAGE_MODEL_WEB_SEARCH language model in Android

### DIFF
--- a/speech_to_text/android/src/main/kotlin/com/csdcorp/speech_to_text/SpeechToTextPlugin.kt
+++ b/speech_to_text/android/src/main/kotlin/com/csdcorp/speech_to_text/SpeechToTextPlugin.kt
@@ -267,15 +267,14 @@ public class SpeechToTextPlugin :
             result.success(false)
             return
         }
+        var listenMode = enumValues<ListenMode>()[listenModeIndex]
+
         resultSent = false
-        createRecognizer(onDevice)
+        createRecognizer(onDevice, listenMode)
         minRms = 1000.0F
         maxRms = -100.0F
         debugLog("Start listening")
-        var listenMode = ListenMode.deviceDefault
-        if ( listenModeIndex == ListenMode.dictation.ordinal) {
-            listenMode = ListenMode.dictation
-        }
+
         optionallyStartBluetooth()
         setupRecognizerIntent(languageTag, partialResults, listenMode, onDevice )
         handler.post {
@@ -570,7 +569,7 @@ public class SpeechToTextPlugin :
         return list.firstOrNull()?.serviceInfo?.let { ComponentName(it.packageName, it.name) }
     }
 
-    private fun createRecognizer(onDevice: Boolean) {
+    private fun createRecognizer(onDevice: Boolean, listenMode: ListenMode) {
         if ( null != speechRecognizer && onDevice == lastOnDevice ) {
             return
         }
@@ -617,7 +616,7 @@ public class SpeechToTextPlugin :
             }
         }
         debugLog("before setup intent")
-        setupRecognizerIntent(defaultLanguageTag, true, ListenMode.deviceDefault, false )
+        setupRecognizerIntent(defaultLanguageTag, true, listenMode, false )
         debugLog("after setup intent")
     }
 
@@ -633,7 +632,12 @@ public class SpeechToTextPlugin :
                 run {
                     recognizerIntent = Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH).apply {
                         debugLog("In RecognizerIntent apply")
-                        putExtra(RecognizerIntent.EXTRA_LANGUAGE_MODEL, RecognizerIntent.LANGUAGE_MODEL_FREE_FORM)
+                        if (listenMode == ListenMode.search) {
+                            putExtra(RecognizerIntent.EXTRA_LANGUAGE_MODEL, RecognizerIntent.LANGUAGE_MODEL_WEB_SEARCH)
+                        }
+                        else {
+                            putExtra(RecognizerIntent.EXTRA_LANGUAGE_MODEL, RecognizerIntent.LANGUAGE_MODEL_FREE_FORM)
+                        }
                         debugLog("put model")
                         val localContext = pluginContext
                         if (null != localContext) {


### PR DESCRIPTION
Android speech recognition has an issue with recognizing short (1-3 letter) words as stated per: [https://issuetracker.google.com/issues/280288200](https://issuetracker.google.com/issues/280288200). 

It appears that Google has finally fixed/improved this by setting `EXTRA_LANGUAGE_MODEL=LANGUAGE_MODEL_WEB_SEARCH`
I propose that we could hook this functionality to the `ListenMode.search` for Android that is already supported by iOS and maps to `SFSpeechRecognitionTaskHint.search`.