### PR TITLE
fix Swift concurrency issue in SpeechToTextPlugin

### DIFF
--- a/speech_to_text/CHANGELOG.md
+++ b/speech_to_text/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 7.3.1 (Pending)
+
+### Fix
+* Fixed Swift concurrency error with captured variables in Task closure on iOS - resolves build failure with "Reference to captured var 'localeStr' in concurrently-executing code"
+
 ## 7.3.0
 
 ### New

--- a/speech_to_text/darwin/speech_to_text/Sources/speech_to_text/SpeechToTextPlugin.swift
+++ b/speech_to_text/darwin/speech_to_text/Sources/speech_to_text/SpeechToTextPlugin.swift
@@ -171,11 +171,18 @@ public class SpeechToTextPlugin: NSObject, FlutterPlugin {
         return
       }
         if #available(iOS 13.0, *) {
+            let capturedLocaleStr = localeStr
+            let capturedPartialResults = partialResults
+            let capturedOnDevice = onDevice
+            let capturedListenMode = listenMode
+            let capturedSampleRate = sampleRate
+            let capturedAutoPunctuation = autoPunctuation
+            let capturedEnableHaptics = enableHaptics
             Task {
                 listenForSpeech(
-                    result, localeStr: localeStr, partialResults: partialResults, onDevice: onDevice,
-                    listenMode: listenMode, sampleRate: sampleRate, autoPunctuation: autoPunctuation,
-                    enableHaptics: enableHaptics)
+                    result, localeStr: capturedLocaleStr, partialResults: capturedPartialResults, onDevice: capturedOnDevice,
+                    listenMode: capturedListenMode, sampleRate: capturedSampleRate, autoPunctuation: capturedAutoPunctuation,
+                    enableHaptics: capturedEnableHaptics)
             }
         } else {
             listenForSpeech(


### PR DESCRIPTION


Swift Compiler Error (Xcode): Reference to captured var 'localeStr' in concurrently-executing code
/Users/runner/.pub-cache/hosted/pub.dev/speech_to_text-7.3.0/darwin/speech_to_text/Sources/speech_to_text/SpeechToTextPlugin.swift:175:39
