### PR TITLE
fix: bump macOS SPM deployment target from 10.14 to 10.15 for SFTranscription

### DIFF
--- a/speech_to_text/darwin/speech_to_text/Package.swift
+++ b/speech_to_text/darwin/speech_to_text/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
     name: "speech_to_text",
     platforms: [
         .iOS("12.0"),
-        .macOS("10.14")
+        .macOS("10.15")
     ],
     products: [
         .library(name: "speech-to-text", targets: ["speech_to_text"])


### PR DESCRIPTION
## Problem

`speech_to_text` 7.3.0 fails to compile on macOS when using Swift Package Manager (SPM) instead of CocoaPods.

The `Package.swift` declares `.macOS("10.14")` but several types in `SpeechToTextPlugin.swift` (e.g. `SFTranscription`) require macOS 10.15+.

This causes Xcode to emit:
```
'SFTranscription' is only available in macOS 10.15 or newer
```

Related issues: #662, #649

## Fix

One-line change: bump `.macOS("10.14")` → `.macOS("10.15")` in `speech_to_text/darwin/speech_to_text/Package.swift`.

This aligns the SPM minimum deployment target with the actual API requirements of the plugin code.