### PR TITLE
feat: add contextualPhrases to SpeechListenOptions

### DIFF
--- a/speech_to_text/CHANGELOG.md
+++ b/speech_to_text/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 7.4.0-beta.9
+
+### New
+* Added `contextualPhrases` to `SpeechListenOptions` to bias recognition toward
+  domain-specific vocabulary or proper nouns. Maps to
+  `SFSpeechRecognitionRequest.contextualStrings` on iOS and
+  `RecognizerIntent.EXTRA_BIASING_STRINGS` on Android 13+ (silently ignored on
+  earlier Android versions and on web).
+
 ## 7.4.0-beta.8
 
 ### New

--- a/speech_to_text/android/src/main/kotlin/com/csdcorp/speech_to_text/SpeechToTextPlugin.kt
+++ b/speech_to_text/android/src/main/kotlin/com/csdcorp/speech_to_text/SpeechToTextPlugin.kt
@@ -127,6 +127,7 @@ public class SpeechToTextPlugin :
     private var previousPartialResults: Boolean = true
     private var previousListenMode: ListenMode = ListenMode.deviceDefault
     private var previousPauseFor: Int? = null
+    private var previousContextualPhrases: List<String>? = null
     private var lastFinalTime: Long = 0
     private var speechStartTime: Long = 0
     private var minRms: Float = 1000.0F
@@ -217,7 +218,9 @@ public class SpeechToTextPlugin :
                     }
                     val pauseFor =
                         call.argument<Int?>("pauseFor")
-                    startListening(result, localeId, partialResults, listenModeIndex, onDevice, pauseFor )
+                    val contextualPhrases =
+                        call.argument<List<String>>("contextualPhrases")
+                    startListening(result, localeId, partialResults, listenModeIndex, onDevice, pauseFor, contextualPhrases )
                 }
                 "stop" -> stopListening(result)
                 "cancel" -> cancelListening(result)
@@ -281,7 +284,8 @@ public class SpeechToTextPlugin :
     }
 
     private fun startListening(result: Result, languageTag: String, partialResults: Boolean,
-                               listenModeIndex: Int, onDevice: Boolean, pauseFor: Int?) {
+                               listenModeIndex: Int, onDevice: Boolean, pauseFor: Int?,
+                               contextualPhrases: List<String>?) {
         if (sdkVersionTooLow() || isNotInitialized() || isListening()) {
             result.success(false)
             return
@@ -295,7 +299,7 @@ public class SpeechToTextPlugin :
         debugLog("Start listening")
 
         optionallyStartBluetooth()
-        setupRecognizerIntent(languageTag, partialResults, listenMode, onDevice, pauseFor )
+        setupRecognizerIntent(languageTag, partialResults, listenMode, onDevice, pauseFor, contextualPhrases )
         handler.post {
             run {
                 speechRecognizer?.startListening(recognizerIntent)
@@ -647,20 +651,22 @@ public class SpeechToTextPlugin :
             }
         }
         debugLog("before setup intent")
-        setupRecognizerIntent(defaultLanguageTag, true, listenMode, false, pauseFor )
+        setupRecognizerIntent(defaultLanguageTag, true, listenMode, false, pauseFor, null )
         debugLog("after setup intent")
     }
 
-    private fun setupRecognizerIntent(languageTag: String, partialResults: Boolean, listenMode: ListenMode, onDevice: Boolean, pauseFor: Int? ) {
+    private fun setupRecognizerIntent(languageTag: String, partialResults: Boolean, listenMode: ListenMode, onDevice: Boolean, pauseFor: Int?, contextualPhrases: List<String>? ) {
         debugLog("setupRecognizerIntent")
         if (previousRecognizerLang == null ||
                 previousRecognizerLang != languageTag ||
                 partialResults != previousPartialResults || previousListenMode != listenMode ||
-                previousPauseFor != pauseFor ) {
+                previousPauseFor != pauseFor ||
+                previousContextualPhrases != contextualPhrases ) {
             previousRecognizerLang = languageTag;
             previousPartialResults = partialResults
             previousListenMode = listenMode
             previousPauseFor = pauseFor
+            previousContextualPhrases = contextualPhrases
             handler.post {
                 run {
                     recognizerIntent = Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH).apply {
@@ -691,6 +697,13 @@ public class SpeechToTextPlugin :
 
                         pauseFor?.also {
                             putExtra(RecognizerIntent.EXTRA_SPEECH_INPUT_COMPLETE_SILENCE_LENGTH_MILLIS, it)
+                        }
+
+                        // EXTRA_BIASING_STRINGS was added in Android 13 (API 33).
+                        // On earlier versions the recognizer silently ignores the
+                        // hint, which is the same behavior as not setting it.
+                        if (Build.VERSION.SDK_INT >= 33 && !contextualPhrases.isNullOrEmpty()) {
+                            putExtra(RecognizerIntent.EXTRA_BIASING_STRINGS, contextualPhrases.toTypedArray())
                         }
                     }
                 }

--- a/speech_to_text/darwin/speech_to_text/Sources/speech_to_text/SpeechToTextPlugin.swift
+++ b/speech_to_text/darwin/speech_to_text/Sources/speech_to_text/SpeechToTextPlugin.swift
@@ -165,6 +165,7 @@ public class SpeechToTextPlugin: NSObject, FlutterPlugin {
       if let localeParam = argsArr["localeId"] as? String {
         localeStr = localeParam
       }
+      let contextualPhrases = argsArr["contextualPhrases"] as? [String]
       guard let listenMode = ListenMode(rawValue: listenModeIndex) else {
         DispatchQueue.main.async {
           result(
@@ -183,17 +184,18 @@ public class SpeechToTextPlugin: NSObject, FlutterPlugin {
             let capturedSampleRate = sampleRate
             let capturedAutoPunctuation = autoPunctuation
             let capturedEnableHaptics = enableHaptics
+            let capturedContextualPhrases = contextualPhrases
             Task {
                 listenForSpeech(
                     result, localeStr: capturedLocaleStr, partialResults: capturedPartialResults, onDevice: capturedOnDevice,
                     listenMode: capturedListenMode, sampleRate: capturedSampleRate, autoPunctuation: capturedAutoPunctuation,
-                    enableHaptics: capturedEnableHaptics)
+                    enableHaptics: capturedEnableHaptics, contextualPhrases: capturedContextualPhrases)
             }
         } else {
             listenForSpeech(
                 result, localeStr: localeStr, partialResults: partialResults, onDevice: onDevice,
                 listenMode: listenMode, sampleRate: sampleRate, autoPunctuation: autoPunctuation,
-                enableHaptics: enableHaptics)
+                enableHaptics: enableHaptics, contextualPhrases: contextualPhrases)
         }
     case SwiftSpeechToTextMethods.stop.rawValue:
         if #available(iOS 13.0, *) {
@@ -483,7 +485,7 @@ public class SpeechToTextPlugin: NSObject, FlutterPlugin {
   private func listenForSpeech(
     _ result: @escaping FlutterResult, localeStr: String?, partialResults: Bool,
     onDevice: Bool, listenMode: ListenMode, sampleRate: Int, autoPunctuation: Bool,
-    enableHaptics: Bool
+    enableHaptics: Bool, contextualPhrases: [String]? = nil
   ) {
     if nil != currentTask || listening {
       sendBoolResult(false, result)
@@ -556,6 +558,9 @@ public class SpeechToTextPlugin: NSObject, FlutterPlugin {
       currentRequest.shouldReportPartialResults = true
       if #available(iOS 13.0, *), onDevice {
         currentRequest.requiresOnDeviceRecognition = true
+      }
+      if let phrases = contextualPhrases, !phrases.isEmpty {
+        currentRequest.contextualStrings = phrases
       }
       switch listenMode {
       case ListenMode.dictation:

--- a/speech_to_text/pubspec.yaml
+++ b/speech_to_text/pubspec.yaml
@@ -1,6 +1,6 @@
 name: speech_to_text
 description: A Flutter plugin that exposes device specific speech to text recognition capability.
-version: 7.4.0-beta.8
+version: 7.4.0-beta.9
 homepage: https://github.com/csdcorp/speech_to_text
 
 environment:

--- a/speech_to_text_platform_interface/CHANGELOG.md
+++ b/speech_to_text_platform_interface/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.5.0
+- New `contextualPhrases` property on `SpeechListenOptions` for biasing
+  recognition toward domain-specific vocabulary. Forwarded to platforms as
+  the `contextualPhrases` listen-method argument.
+
 ## 2.4.0
 - New properties on SpeechListenOptions for pauseFor, listenFor and localeId
 

--- a/speech_to_text_platform_interface/lib/method_channel_speech_to_text.dart
+++ b/speech_to_text_platform_interface/lib/method_channel_speech_to_text.dart
@@ -117,6 +117,10 @@ class MethodChannelSpeechToText extends SpeechToTextPlatform {
     if (null != (localeId ?? options?.localeId)) {
       listenParams["localeId"] = (localeId ?? options?.localeId);
     }
+    final phrases = options?.contextualPhrases;
+    if (phrases != null && phrases.isNotEmpty) {
+      listenParams["contextualPhrases"] = phrases;
+    }
     return await _channel.invokeMethod<bool>('listen', listenParams) ?? false;
   }
 

--- a/speech_to_text_platform_interface/lib/speech_to_text_platform_interface.dart
+++ b/speech_to_text_platform_interface/lib/speech_to_text_platform_interface.dart
@@ -66,6 +66,7 @@ class SpeechListenOptions {
   final Duration? pauseFor;
   final Duration? listenFor;
   final String? localeId;
+  final List<String>? contextualPhrases;
 
   SpeechListenOptions({
     /// If true the listen session will automatically be canceled on a permanent error.
@@ -113,6 +114,15 @@ class SpeechListenOptions {
     /// The locale to use for the listen session, if null the system default
     /// locale will be used. This is only supported on iOS and Android.
     this.localeId = null,
+
+    /// Phrases to bias recognition toward — domain-specific vocabulary,
+    /// proper nouns, or technical terms that the system might otherwise
+    /// mis-transcribe. On iOS this maps to
+    /// `SFSpeechRecognitionRequest.contextualStrings`. On Android this
+    /// maps to `RecognizerIntent.EXTRA_BIASING_STRINGS` and requires
+    /// API 33 (Android 13) or later — earlier versions silently ignore
+    /// the hint. Web and other platforms also ignore the hint.
+    this.contextualPhrases,
   });
 
   SpeechListenOptions copyWith({
@@ -126,6 +136,7 @@ class SpeechListenOptions {
     Duration? pauseFor,
     Duration? listenFor,
     String? localeId,
+    List<String>? contextualPhrases,
   }) {
     return SpeechListenOptions(
         cancelOnError: cancelOnError ?? this.cancelOnError,
@@ -137,7 +148,8 @@ class SpeechListenOptions {
         enableHapticFeedback: enableHapticFeedback ?? this.enableHapticFeedback,
         pauseFor: pauseFor ?? this.pauseFor,
         listenFor: listenFor ?? this.listenFor,
-        localeId: localeId ?? this.localeId);
+        localeId: localeId ?? this.localeId,
+        contextualPhrases: contextualPhrases ?? this.contextualPhrases);
   }
 }
 

--- a/speech_to_text_platform_interface/pubspec.yaml
+++ b/speech_to_text_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the speech_to_text plugin.
 homepage: https://github.com/csdcorp/speech_to_text/speech_to_text_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.4.0
+version: 2.5.0
 
 dependencies:
   flutter:

--- a/speech_to_text_platform_interface/test/method_channel_speech_to_text_test.dart
+++ b/speech_to_text_platform_interface/test/method_channel_speech_to_text_test.dart
@@ -120,6 +120,28 @@ void main() {
           isTrue);
       expect(channelHandler.sampleRate, 10000);
     });
+    test('passes contextualPhrases parameter when non-empty', () async {
+      expect(
+          await speechToText?.listen(
+            options: SpeechListenOptions(
+                contextualPhrases: const ['Nosema', 'varroa', 'brood box']),
+          ),
+          isTrue);
+      expect(
+          channelHandler.contextualPhrases, ['Nosema', 'varroa', 'brood box']);
+    });
+    test('omits contextualPhrases when null', () async {
+      expect(await speechToText?.listen(), isTrue);
+      expect(channelHandler.contextualPhrases, isNull);
+    });
+    test('omits contextualPhrases when empty', () async {
+      expect(
+          await speechToText?.listen(
+            options: SpeechListenOptions(contextualPhrases: const []),
+          ),
+          isTrue);
+      expect(channelHandler.contextualPhrases, isNull);
+    });
   });
   group('control methods invoked as expected', () {
     test('stop invoked', () async {

--- a/speech_to_text_platform_interface/test/speech_listen_options_test.dart
+++ b/speech_to_text_platform_interface/test/speech_listen_options_test.dart
@@ -2,6 +2,17 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:speech_to_text_platform_interface/speech_to_text_platform_interface.dart';
 
 void main() {
+  group('constructor', () {
+    test('contextualPhrases defaults to null', () {
+      final options = SpeechListenOptions();
+      expect(options.contextualPhrases, isNull);
+    });
+    test('contextualPhrases is stored when supplied', () {
+      final options = SpeechListenOptions(
+          contextualPhrases: const ['Nosema', 'Langstroth']);
+      expect(options.contextualPhrases, ['Nosema', 'Langstroth']);
+    });
+  });
   group('copyWith', () {
     test('modifies expected properties', () async {
       final options = SpeechListenOptions(
@@ -12,6 +23,7 @@ void main() {
         cancelOnError: true,
         autoPunctuation: true,
         enableHapticFeedback: true,
+        contextualPhrases: const ['Nosema'],
       );
       final modifiedOptions = options.copyWith(
         onDevice: false,
@@ -21,6 +33,7 @@ void main() {
         cancelOnError: false,
         autoPunctuation: false,
         enableHapticFeedback: false,
+        contextualPhrases: const ['varroa', 'brood box'],
       );
       expect(modifiedOptions.onDevice, false);
       expect(modifiedOptions.partialResults, false);
@@ -29,6 +42,13 @@ void main() {
       expect(modifiedOptions.cancelOnError, false);
       expect(modifiedOptions.autoPunctuation, false);
       expect(modifiedOptions.enableHapticFeedback, false);
+      expect(modifiedOptions.contextualPhrases, ['varroa', 'brood box']);
+    });
+    test('preserves contextualPhrases when not modified', () {
+      final options = SpeechListenOptions(
+          contextualPhrases: const ['Nosema', 'varroa']);
+      final modified = options.copyWith(onDevice: true);
+      expect(modified.contextualPhrases, ['Nosema', 'varroa']);
     });
   });
 }

--- a/speech_to_text_platform_interface/test/test_speech_channel_handler.dart
+++ b/speech_to_text_platform_interface/test/test_speech_channel_handler.dart
@@ -30,6 +30,7 @@ class TestSpeechChannelHandler {
   bool? debugLogging;
   int? listenMode = 0;
   int? sampleRate = 0;
+  List<String>? contextualPhrases;
   dynamic initOption;
   static const String localeId1 = 'en_US';
   static const String localeId2 = 'fr_CA';
@@ -96,6 +97,8 @@ class TestSpeechChannelHandler {
         partialResults = methodCall.arguments['partialResults'];
         listenMode = methodCall.arguments['listenMode'];
         sampleRate = methodCall.arguments['sampleRate'];
+        contextualPhrases =
+            (methodCall.arguments['contextualPhrases'] as List?)?.cast<String>();
         // await _speech.processMethodCall(MethodCall(
         //     SpeechToText.notifyStatusMethod, listeningStatusResponse));
         return listenResult;
@@ -150,6 +153,7 @@ class TestSpeechChannelHandler {
     partialResults = false;
     listenMode = 0;
     sampleRate = 0;
+    contextualPhrases = null;
     initOption = null;
     debugLogging = null;
   }


### PR DESCRIPTION
## Summary

Adds a `contextualPhrases: List<String>?` option to `SpeechListenOptions` that maps onto the recognizer biasing APIs both platforms already provide:

- **iOS:** [`SFSpeechRecognitionRequest.contextualStrings`](https://developer.apple.com/documentation/speech/sfspeechrecognitionrequest/contextualstrings) — \"phrases that should be recognized, even if they are not in the system vocabulary.\"
- **Android:** [`RecognizerIntent.EXTRA_BIASING_STRINGS`](https://developer.android.com/reference/android/speech/RecognizerIntent#EXTRA_BIASING_STRINGS) — \"a list of strings that may be expected during the recognition.\" Added in API 33; silently ignored on earlier versions, matching the platform's own no-op behavior.
- **Web / Windows / macOS:** ignored. Field is optional and nullable so existing callers are unaffected.

## Motivation

Apps transcribing domain-specific speech (medical, legal, technical, brand names, less-common proper nouns) hit a wall: the recognizer's general vocabulary mis-transcribes uncommon terms. Without `contextualStrings` exposed at the Dart layer, plugin users have no way to provide vocabulary hints short of forking the package — which is the situation that prompted this PR.

For context, the use case driving this in our app is beekeeping inspection notes: \"brood\" → \"brewed\", \"Nosema\" → \"noxema\", \"varroa\" → \"barometer\", \"Langstroth\" → \"lane straw\". Passing those terms as biasing hints raises their probability without requiring a custom language model.

## Implementation

Plumbing only — no behavior change when `contextualPhrases` is null or empty.

- `speech_to_text_platform_interface`: new field on `SpeechListenOptions` + `copyWith` + forwarded through `MethodChannelSpeechToText.listen()` as a list arg. Empty/null lists are omitted from the channel call rather than sent as empty arrays.
- iOS Swift plugin: parses the optional arg, sets `currentRequest.contextualStrings` after creating the `SFSpeechAudioBufferRecognitionRequest`.
- Android Kotlin plugin: parses the optional arg, threads it through `startListening` and `setupRecognizerIntent`; sets `EXTRA_BIASING_STRINGS` on API 33+ via `Build.VERSION.SDK_INT >= 33` guard. Cache key in `setupRecognizerIntent` extended so vocab changes mid-session correctly invalidate the cached intent.

## Tests

Added in `speech_to_text_platform_interface/test`:

- `SpeechListenOptions` constructor: default-null and explicit-list.
- `copyWith`: new field carries through and is preserved when not modified.
- `MethodChannelSpeechToText.listen`: forwards a non-empty list, omits the arg when null, omits when empty.

Existing 28 platform-interface tests + 136 main-package tests all pass.

## Versions

- `speech_to_text` 7.4.0-beta.8 → 7.4.0-beta.9
- `speech_to_text_platform_interface` 2.4.0 → 2.5.0

CHANGELOG entries included.

## Test plan

- [x] `flutter test` passes in `speech_to_text_platform_interface`
- [x] `flutter test` passes in `speech_to_text`
- [x] Built and run against a real iOS device — `contextualStrings` correctly biases recognition toward provided phrases
- [x] Built and run against Android 13+ device — `EXTRA_BIASING_STRINGS` correctly biases when the recognizer supports it
- [ ] Maintainer to verify on Windows/macOS/web (no behavior change expected; the new field is ignored on those platforms)