### PR TITLE
Fix Windows build: extern "C" + dllexport on plugin registrant

### DIFF
--- a/speech_to_text_windows/windows/speech_to_text_windows.cpp
+++ b/speech_to_text_windows/windows/speech_to_text_windows.cpp
@@ -3,7 +3,7 @@
 
 #include "speech_to_text_windows_plugin.h"
 
-void SpeechToTextWindowsRegisterWithRegistrar(
+extern "C" __declspec(dllexport) void SpeechToTextWindowsRegisterWithRegistrar(
     FlutterDesktopPluginRegistrarRef registrar) {
   speech_to_text_windows::SpeechToTextWindowsPlugin::RegisterWithRegistrar(
       flutter::PluginRegistrarManager::GetInstance()


### PR DESCRIPTION
# Fix Windows build: extern "C" + dllexport on plugin registrant

## Summary

`speech_to_text_windows`'s plugin registrant function is defined without `extern "C" __declspec(dllexport)`, while the header declares it as `extern "C"` with `FLUTTER_PLUGIN_EXPORT`. The mismatch causes any host project that depends on `speech_to_text` on Windows to fail at the link step.

## Bug

`speech_to_text_windows/windows/speech_to_text_windows.cpp`:

```cpp
void SpeechToTextWindowsRegisterWithRegistrar(
    FlutterDesktopPluginRegistrarRef registrar) {
  ...
}
```

`speech_to_text_windows/windows/include/speech_to_text_windows/speech_to_text_windows.h`:

```cpp
#if defined(__cplusplus)
extern "C" {
#endif

FLUTTER_PLUGIN_EXPORT void SpeechToTextWindowsRegisterWithRegistrar(
    FlutterDesktopPluginRegistrarRef registrar);
```

Because the definition lacks both the C linkage attribute and the export, the C++ compiler emits a mangled symbol while `generated_plugin_registrant.cc` in the host app expects the C-linkage `SpeechToTextWindowsRegisterWithRegistrar`. The result on the host project's link step:

```
error C3861: 'SpeechToTextWindowsRegisterWithRegistrar': Bezeichner wurde nicht gefunden
```

## Fix

Add `extern "C" __declspec(dllexport)` to the registrant definition (single-line change). Diff:

```diff
-void SpeechToTextWindowsRegisterWithRegistrar(
+extern "C" __declspec(dllexport) void SpeechToTextWindowsRegisterWithRegistrar(
     FlutterDesktopPluginRegistrarRef registrar) {
```

## Reproduction

Minimal repro on any Flutter project:

```yaml
# pubspec.yaml
dependencies:
  flutter:
    sdk: flutter
  speech_to_text: ^7.0.0
```

```sh
flutter pub get
flutter run -d windows
```

Build fails at link step with `C3861` on `SpeechToTextWindowsRegisterWithRegistrar`. With the fix applied the build succeeds and the plugin loads correctly at runtime.

## Test environment

- Windows 11 24H2 (build 26200)
- Flutter 3.24+
- CMake 3.27+
- speech_to_text 7.3.0 → speech_to_text_windows 1.0.0+beta.8 (the version currently on pub.dev)

## Notes

- Tested in production via `dependency_overrides` on a Goebel-internal project for several weeks; runtime behaviour is unchanged.
- The fix is the minimum that aligns definition with declaration. No other changes needed.
- Previously the public header also had a copy-pasted include guard from `local_auth_windows`; that has already been resolved upstream by switching to `#pragma once`. This PR only addresses the linkage bug that's still present at HEAD.
