### PR TITLE
Android: destroy and recreate the SpeechRecognizer on cancel()

### DIFF
--- a/speech_to_text/CHANGELOG.md
+++ b/speech_to_text/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Updates minimum supported SDK version to Flutter 3.44/Dart 3.12.
 - Migrates to built-in Kotlin
+- Android: `cancel()` now destroys and recreates the `SpeechRecognizer`, so a `listen()` right after it is no longer rejected with `error_client` and the cancelled session's late error no longer reaches the new session
 
 ## 7.4.0
 

--- a/speech_to_text/android/src/main/kotlin/com/csdcorp/speech_to_text/SpeechToTextPlugin.kt
+++ b/speech_to_text/android/src/main/kotlin/com/csdcorp/speech_to_text/SpeechToTextPlugin.kt
@@ -353,10 +353,9 @@ public class SpeechToTextPlugin :
         handler.post {
             run {
                 speechRecognizer?.cancel()
+                speechRecognizer?.destroy()
+                speechRecognizer = null
             }
-        }
-        if ( !recognizerStops ) {
-            destroyRecognizer()
         }
         notifyListening(isRecording = false)
         result.success(true)


### PR DESCRIPTION
Fixes #678.

`cancelListening()` now calls `destroy()` right after `cancel()` in the same main-thread post and nulls the instance; the next `listen()` creates a fresh `SpeechRecognizer` through the existing `createRecognizer()` path.

Why: `cancel()` alone leaves the instance's listener registered in the `RecognitionService` until the service has processed it, and the cancelled session's `CANCELLED` error still arrives on the plugin's `RecognitionListener` 25–51 ms later. A `listen()` started in between treats it as its own error (`notifyListening(false)` on a live session), after which the following `listen()` is rejected with `error_client` ("already in session"). `destroy()` cancels with `isShutdown` and detaches the internal listener, so the framework drops the late callback, and a new instance has a new listener binder.

- Only the cancel path changes; `stop()` is untouched.
- The SDK 29 delayed `destroyRecognizer()` call in `cancelListening` goes away, since the destroy is now unconditional and synchronous. The stop path keeps it.
- Recreating the recognizer costs one service bind per `listen()` after a cancel, ~100 ms on a Pixel 7, which is less than the workaround delays apps use today.

Tested on a Pixel 7 (Android 16, Google recognizer) with an app that restarts recognition between short utterances: cancel → `onMicrophoneOpened` 82–148 ms per restart, no `already in session` rejection, no stray `error_client`/`error_busy`, no `ERROR_RECOGNIZER_BUSY`, over 25 restarts at 1.5 s and 0.5 s pacing. Before, with the same script and a 250 ms delay before `listen()`, 296–404 ms; without the delay, `error_client` on every restart.

Easy way to see it in the example app: call `cancel()` and then `listen()` immediately. On `main` you get `error_client` and `done`; with this change the new session reports `listening` and delivers results.
